### PR TITLE
Updated script to work with latest bitcoind

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ define command {
         command_name                   check_bitcoin_connections
 }
 
-define command {
-        command_line                   $USER1$/bitcoin/check_bitcoind.sh -u $ARG1$ -p $ARG2$ -H $HOSTADDRESS$ -P $ARG3$ -B $ARG4$ -w $ARG5$ -c $ARG6$ -t errors
-        command_name                   check_bitcoin_errors
-}
 ```
 
 ### Nagios Services
@@ -50,21 +46,13 @@ define service {
         use                            generic-service
 }
 
-define service {
-        check_command                  check_bitcoin_errors!<USERNAME>!<PASSWORD>!<PORT>!<CURRENCY>!<WARN>!<CRIT>
-        host_name                      <HOSTNAME>
-        service_description            Bitcoind Errors
-        use                            generic-service
-}
-
 ```
 
 ## Service Descriptions
 Check Type | Description | Example output
 ---------- | ----------- | --------------
 blockchain | Check the height of the node blockchain against [Blockexplorer](https://blockexplorer.com) | `CRITICAL - node block height = 380882, global block height = 494377` 
-connections | Check the number of connections (peers) reported | `OK - network connections = 8`
-errors | Check for any errors reported by the bitcoind process | `OK`
+connections | Check the number of connections (peers) reported | `OK - network connections = 8``
 
 ## Command line options
 Argument | Description | Example
@@ -76,5 +64,4 @@ Argument | Description | Example
 -B | Currency to use (only for blockchain check) - either `btc` or `bch` | btc
 -w | Warning level to use for Nagios output | 5
 -c | Critical level to use for Nagios output | 10
--t | Type of check to run - either `blockchain`, `connections` or `errors` | blockchain
-
+-t | Type of check to run - either `blockchain` or `connections` | blockchain

--- a/check_bitcoind.sh
+++ b/check_bitcoind.sh
@@ -4,6 +4,9 @@
 # Matt Dyson - 10/10/17
 # github.com/mattdy/nagios-bitcoin
 #
+# updated by Louis - 2018-09-22
+# github.com/louiseth1/nagios-bitcoin
+#
 # Nagios plugin to check the given Bitcoin node against blockexplorer.com
 # Can be used on BTC or BCH nodes as specified
 #
@@ -13,160 +16,157 @@ use_bch=False
 coin="btc" # Default to BTC if not specified
 
 while getopts ":B:H:P:w:c:u:p:t:" opt; do
-	case $opt in
-		B)
-			coin=$OPTARG
-			;;
-		H)
-			node_address=$OPTARG
-			;;
-		P)
-			node_port=$OPTARG
-			;;
-		w)
-			warn_level=$OPTARG
-			;;
-		c)
-			crit_level=$OPTARG
-			;;
-		u)
-			node_user=$OPTARG
-			;;
-		p)
-			node_pass=$OPTARG
-			;;
-		t)
-			checktype=$OPTARG
-			;;
-		\?)
-			echo "UNKNOWN - Invalid option $OPTARG" >&2
-			exit 3
-			;;
-		:)
-			echo "UNKNOWN - Option $OPTARG requires an argument" >&2
-			exit 3
-		;;
-	esac
+        case $opt in
+                B)
+                        coin=$OPTARG
+                        ;;
+                H)
+                        node_address=$OPTARG
+                        ;;
+                P)
+                        node_port=$OPTARG
+                        ;;
+                w)
+                        warn_level=$OPTARG
+                        ;;
+                c)
+                        crit_level=$OPTARG
+                        ;;
+                u)
+                        node_user=$OPTARG
+                        ;;
+                p)
+                        node_pass=$OPTARG
+                        ;;
+                t)
+                        checktype=$OPTARG
+                        ;;
+                \?)
+                        echo "UNKNOWN - Invalid option $OPTARG" >&2
+                        exit 3
+                        ;;
+                :)
+                        echo "UNKNOWN - Option $OPTARG requires an argument" >&2
+                        exit 3
+                ;;
+        esac
 done
 
 if [ -z "$node_address" ]; then
-	node_address=localhost
+        node_address=localhost
 fi
 
 if [ -z "$node_port" ]; then
-	node_port=8332
+        node_port=8332
 fi
 
 if [ -z "$warn_level" ]; then
-	echo "UNKNOWN - Must specify a warning level"
-	exit 3
+        echo "UNKNOWN - Must specify a warning level"
+        exit 3
 fi
 
 if [ -z "$crit_level" ]; then
-	echo "UNKNOWN - Must specify a critical level"
-	exit 3
+        echo "UNKNOWN - Must specify a critical level"
+        exit 3
 fi
 
 if [ -z "$checktype" ]; then
-	echo "UNKNOWN - Must specify a check to perform (blockchain/connections/errors)"
-	exit 3
+        echo "UNKNOWN - Must specify a check to perform (blockchain/connections)"
+        exit 3
 fi
 
 if [ -z "$node_user" ]; then
-	echo "UNKNOWN - No username specified"
-	exit 3
+        echo "UNKNOWN - No username specified"
+        exit 3
 fi
 
 if [ -z "$node_pass" ]; then
-	echo "UNKNOWN - No password specified"
-	exit 3
+        echo "UNKNOWN - No password specified"
+        exit 3
 fi
 
 if [ "$coin" != "btc" ] && [ "$coin" != "bch" ]; then
-	echo "UNKNOWN - Invalid coin type specified (btc/bch)"
-	exit 3
-fi
-
-# Get information from node
-node=$(curl --user $node_user:$node_pass -sf --data-binary '{"jsonrpc": "1.0", "id":"check_btc_blockchain", "method": "getinfo", "params": [] }' -H 'content-type: text/plain;' http://$node_address:$node_port/)
-if [ $? -ne "0" ]; then
-	echo "UNKNOWN - Request to bitcoind failed"
-	exit 3
-fi
-
-node_error=$(echo "$node" | jq -r '.error')
-if [ "$node_error" != "null" ]; then
-	echo "UNKNOWN - Request to bitcoind returned error - $node_error"
-	exit 3
+        echo "UNKNOWN - Invalid coin type specified (btc/bch)"
+        exit 3
 fi
 
 case $checktype in
-	"blockchain")
-		node_blocks=$(echo "$node" | jq -r '.result.blocks')
+        "blockchain")
+                # Check the wallet for current blockchain height
+                nodeblock=$(curl --user $node_user:$node_pass -sf --data-binary '{"jsonrpc": "1.0", "id":"check_btc_blockchain", "method": "getblockchaininfo", "params":
+[] }' -H 'content-type: text/plain;' http://$node_address:$node_port/)
+                if [ $? -ne "0" ]; then
+                        echo "UNKNOWN - Request to bitcoind failed"
+                        exit 3
+                fi
 
-		if [ $coin == "bch" ]; then
-			remote_addr="bitcoincash.blockexplorer.com"
-		else
-			remote_addr="blockexplorer.com"
-		fi
+                node_error=$(echo "$nodeblock" | jq -r '.error')
+                if [ "$node_error" != "null" ]; then
+                        echo "UNKNOWN - Request to bitcoind returned error - $node_error"
+                        exit 3
+                fi
 
-		remote=$(curl -sf https://$remote_addr/api/status?q=getInfo)
-		if [ $? -ne "0" ]; then
-			echo "UNKNOWN - Could not fetch remote information"
-			exit 3
-		fi
+                node_blocks=$(echo "$nodeblock" | jq -r '.result.blocks')
+                if [ $coin == "bch" ]; then
+                        remote_addr="bitcoincash.blockexplorer.com"
+                else
+                        remote_addr="blockexplorer.com"
+                fi
 
-		remote_blocks=$(echo "$remote" | jq -r '.info.blocks')
+                remote=$(curl -sf https://$remote_addr/api/status?q=getBlockchainInfo)
+                if [ $? -ne "0" ]; then
+                        echo "UNKNOWN - Could not fetch remote information"
+                        exit 3
+                fi
 
-		diff=$(expr $remote_blocks - $node_blocks)
-		output="node block height = $node_blocks, global block height = $remote_blocks|node=$node_blocks, global=$remote_blocks"
+                remote_blocks=$(echo "$remote" | jq -r '.info.blocks')
 
-		if [ "$diff" -lt "$warn_level" ]; then
-			echo "OK - $output"
-			exit 0
-		elif [ "$diff" -ge "$warn_level" ] && [ "$diff" -lt "$crit_level" ]; then
-			echo "WARNING - $output"
-			exit 1
-		elif [ "$diff" -ge "$crit_level" ]; then
-			echo "CRITICAL - $output"
-			exit 2
-		else
-			echo "UNKNOWN - $output"
-			exit 3
-		fi
-		;;
+                diff=$(expr $remote_blocks - $node_blocks)
+                output="node block height = $node_blocks, global block height = $remote_blocks|node=$node_blocks, global=$remote_blocks"
 
-	"connections")
-		node_conns=$(echo "$node" | jq -r '.result.connections')
-		output="network connections = $node_conns|connections=$node_conns"
-		if [ "$node_conns" -gt "$warn_level" ]; then
-			echo "OK - $output"
-			exit 0
-		elif [ "$node_conns" -le "$warn_level" ] && [ "$node_conns" -gt "$crit_level" ]; then
-			echo "WARNING - $output"
-			exit 1
-		elif [ "$node_conns" -le "$crit_level" ]; then
-			echo "CRITICAL - $output"
-			exit 2
-		else
-			echo "UNKNOWN - $output"
-			exit 3
-		fi
-		;;
+                if [ "$diff" -lt "$warn_level" ]; then
+                        echo "OK - $output"
+                        exit 0
+                elif [ "$diff" -ge "$warn_level" ] && [ "$diff" -lt "$crit_level" ]; then
+                        echo "WARNING - $output"
+                        exit 1
+                elif [ "$diff" -ge "$crit_level" ]; then
+                        echo "CRITICAL - $output"
+                        exit 2
+                else
+                        echo "UNKNOWN - $output"
+                        exit 3
+                fi
+                ;;
 
-	"errors")
-		node_errors=$(echo "$node" | jq -r '.result.errors')
-		if [ -z "$node_errors" ]; then
-			echo "OK"
-			exit 0
-		else
-			echo "CRITICAL - $node_errors"
-			exit 2
-		fi
-		;;
+        "connections")
+                # Check the wallet for peer connections amount
+                nodeconn=$(curl --user $node_user:$node_pass -sf --data-binary '{"jsonrpc": "1.0", "id":"check_btc_blockchain", "method": "getnetworkinfo", "params": [] }' -H 'content-type: text/plain;' http://$node_address:$node_port/)
+                if [ $? -ne "0" ]; then
+                        echo "UNKNOWN - Request to bitcoind failed"
+                        exit 3
+                fi
 
-	*)
-		echo "UNKNOWN - Invalid check type specified"
-		exit 3
-		;;
+                node_error=$(echo "$nodeconn" | jq -r '.error')
+                if [ "$node_error" != "null" ]; then
+                        echo "UNKNOWN - Request to bitcoind returned error - $node_error"
+                        exit 3
+                fi
+
+                node_conns=$(echo "$nodeconn" | jq -r '.result.connections')
+                output="network connections = $node_conns|connections=$node_conns"
+                if [ "$node_conns" -gt "$warn_level" ]; then
+                        echo "OK - $output"
+                        exit 0
+                elif [ "$node_conns" -le "$warn_level" ] && [ "$node_conns" -gt "$crit_level" ]; then
+                        echo "WARNING - $output"
+                        exit 1
+                elif [ "$node_conns" -le "$crit_level" ]; then
+                        echo "CRITICAL - $output"
+                        exit 2
+                else
+                        echo "UNKNOWN - $output"
+                        exit 3
+                fi
+                ;;
 esac


### PR DESCRIPTION
I have updated the script to change RPC commands being used to pull information. In the latest bitcoin-core versions the "getinfo" command has been deprecated.

The previous logic for errors didn't work anymore either so I entirely removed the "errors" check.

Now we can check blockchain height and connection amount properly with this script.